### PR TITLE
Add missing include and fix formatting

### DIFF
--- a/nestkernel/per_thread_bool_indicator.cpp
+++ b/nestkernel/per_thread_bool_indicator.cpp
@@ -52,9 +52,13 @@ PerThreadBoolIndicator::initialize( const size_t num_threads, const bool status 
   per_thread_status_.resize( num_threads, BoolIndicatorUInt64( status ) );
   size_ = num_threads;
   if ( status )
+  {
     are_true_ = num_threads;
+  }
   else
+  {
     are_true_ = 0;
+  }
 }
 
 bool

--- a/nestkernel/per_thread_bool_indicator.h
+++ b/nestkernel/per_thread_bool_indicator.h
@@ -24,6 +24,7 @@
 #define PER_THREAD_BOOL_INDICATOR_H
 
 // C++ includes:
+#include <atomic>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
@jprotze My colleague @otcathatsya noted that GCC 12.3 needs an explicit `#include <atomic>`.  This PR fixes that and one formatting issue. A first benchmark on 128 threads showed only minimal slow-down, on the order of noise.